### PR TITLE
fix: update yarn non-node args

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -55,7 +55,7 @@ brew "tig"
 brew "vim"
 brew "w3m"
 brew "watchman"
-brew "yarn", args: ["without-node"]
+brew "yarn", args: ["ignore-dependencies"]
 brew "zsh"
 brew "ojford/formulae/loginitems"
 brew "remind101/formulae/assume-role"


### PR DESCRIPTION
`without-node` was deprecated awhile back and has now been removed. Updated to `ignore-dependencies` so it'll work.